### PR TITLE
refactor: rm styled log formatting

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,1 @@
-module.exports = {extends: ['@commitlint/config-conventional']};
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@commitlint/cli": "^12.1.1",
-    "@commitlint/config-conventional": "^12.1.1",
-    "ansi-colors": "^4.1.1"
+    "@commitlint/config-conventional": "^12.1.1"
   }
 }


### PR DESCRIPTION
- removes ansi-color dependency (generating a report can be a separate plugin or method)
- outputs everything as a simple json